### PR TITLE
Match a maximum of 4 digits when going from DATE to YEAR

### DIFF
--- a/music_symfarm/defaults.yaml
+++ b/music_symfarm/defaults.yaml
@@ -64,7 +64,7 @@ tagmap:
 # When creating custom variables use lower case. This will prevent conflicts
 # with tags pulled from files (tags are always uppercase)
 fallbacks:
-  year: "{DATE:/(\\d+).*/\\1/}"
+  year: "{DATE:/(\\d{{0,4}}).*/\\1/}"
   ALBUMARTIST: "{ARTIST}"
   ARTIST: "Unknown Artist"
   ALBUM: "Unknown Album"


### PR DESCRIPTION
Some files have dates that are specified as 'YYYYMMDD' instead of the proper 'YYYY-MM-DD'. Since the previous regex would match all leading digits, the year was being extracted as the entire YYYYMMDD-formatted date. This commit fixes this by changing the regex to match a maximum of 4 digits.